### PR TITLE
Replace diagnostic ids with standardized codes

### DIFF
--- a/AsyncMethodNameFixer/AsyncMethodNameFixer/AsyncMethodNameFixerAnalyzer.cs
+++ b/AsyncMethodNameFixer/AsyncMethodNameFixer/AsyncMethodNameFixerAnalyzer.cs
@@ -13,8 +13,8 @@ namespace AsyncMethodNameFixer
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class AsyncMethodNameFixerAnalyzer : DiagnosticAnalyzer
     {
-        public const string AsyncDiagnosticId = "AsyncMethodDiagnostic";
-        public const string NonAsyncDiagnosticId = "NonAsyncMethodDiagnostic";
+        public const string AsyncDiagnosticId = "AMNF0001";
+        public const string NonAsyncDiagnosticId = "AMNF0002";
 
         private static readonly LocalizableString AsyncTitle = new LocalizableResourceString(nameof(Resources.AsyncAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString AsyncMessageFormat = new LocalizableResourceString(nameof(Resources.AsyncAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));


### PR DESCRIPTION
The current diagnostic ids don't fit into the Visual Studio code column. This PR replaces them with something that fits on screen and sorts better.