### PR TITLE
Upgrade to support VS 2022

### DIFF
--- a/AsyncMethodNameFixer.sln
+++ b/AsyncMethodNameFixer.sln
@@ -1,17 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32210.238
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncMethodNameFixer", "AsyncMethodNameFixer\AsyncMethodNameFixer\AsyncMethodNameFixer.csproj", "{474C4094-747B-4C19-9D8F-54C5C35DB1FB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsyncMethodNameFixer", "AsyncMethodNameFixer\AsyncMethodNameFixer\AsyncMethodNameFixer.csproj", "{474C4094-747B-4C19-9D8F-54C5C35DB1FB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncMethodNameFixer.Test", "AsyncMethodNameFixer\AsyncMethodNameFixer.Test\AsyncMethodNameFixer.Test.csproj", "{91BB9172-5878-4160-BA98-7B9319B4AEC2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsyncMethodNameFixer.Test", "AsyncMethodNameFixer\AsyncMethodNameFixer.Test\AsyncMethodNameFixer.Test.csproj", "{91BB9172-5878-4160-BA98-7B9319B4AEC2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncMethodNameFixer.Vsix", "AsyncMethodNameFixer\AsyncMethodNameFixer.Vsix\AsyncMethodNameFixer.Vsix.csproj", "{AE86594F-67C8-48C9-98A7-880C9BC8041D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E3867007-A47D-4596-9CDE-9317669A5FDD}"
 	ProjectSection(SolutionItems) = preProject
-		appveyor.yml = appveyor.yml
+		azure-pipelines.yml = azure-pipelines.yml
 		CHANGELOG.md = CHANGELOG.md
 		README.md = README.md
 	EndProjectSection

--- a/AsyncMethodNameFixer/AsyncMethodNameFixer.Test/AsyncMethodNameFixer.Test.csproj
+++ b/AsyncMethodNameFixer/AsyncMethodNameFixer.Test/AsyncMethodNameFixer.Test.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0-1.final" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AsyncMethodNameFixer/AsyncMethodNameFixer.Vsix/AsyncMethodNameFixer.Vsix.csproj
+++ b/AsyncMethodNameFixer/AsyncMethodNameFixer.Vsix/AsyncMethodNameFixer.Vsix.csproj
@@ -23,6 +23,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -36,7 +37,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AsyncMethodNameFixer.Vsix</RootNamespace>
     <AssemblyName>AsyncMethodNameFixer</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/AsyncMethodNameFixer/AsyncMethodNameFixer.Vsix/source.extension.vsixmanifest
+++ b/AsyncMethodNameFixer/AsyncMethodNameFixer.Vsix/source.extension.vsixmanifest
@@ -14,6 +14,15 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0)" />
         <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
         <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/AsyncMethodNameFixer/AsyncMethodNameFixer.Vsix/source.extension.vsixmanifest
+++ b/AsyncMethodNameFixer/AsyncMethodNameFixer.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="3f1bd9bf-d048-4430-8705-1a26a4819614" Version="2.0.2" Language="en-US" Publisher="Priyanshu Agrawal"/>
+        <Identity Id="3f1bd9bf-d048-4430-8705-1a26a4819614" Version="2.1.0" Language="en-US" Publisher="Priyanshu Agrawal"/>
         <DisplayName>Async Method Name Fixer</DisplayName>
         <Description xml:space="preserve">The easiest way to analyze and fix method names for asynchronous methods.</Description>
         <MoreInfo>https://github.com/priyanshu92/AsyncMethodNameFixer</MoreInfo>

--- a/AsyncMethodNameFixer/AsyncMethodNameFixer.Vsix/source.extension1.cs
+++ b/AsyncMethodNameFixer/AsyncMethodNameFixer.Vsix/source.extension1.cs
@@ -11,7 +11,7 @@ namespace AsyncMethodNameFixer.Vsix
         public const string Name = "Async Method Name Fixer";
         public const string Description = @"The easiest way to analyze and fix method names for asynchronous methods.";
         public const string Language = "en-US";
-        public const string Version = "2.0.2";
+        public const string Version = "2.1.0";
         public const string Author = "Priyanshu Agrawal";
         public const string Tags = "analyzer, async, asynchronous, C#, code analysis, name fix, refactoring, roslyn";
     }

--- a/AsyncMethodNameFixer/AsyncMethodNameFixer/AsyncMethodNameFixer.csproj
+++ b/AsyncMethodNameFixer/AsyncMethodNameFixer/AsyncMethodNameFixer.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>AsyncMethodNameFixer</PackageId>
-    <PackageVersion>2.0.2.0</PackageVersion>
+    <PackageVersion>2.1.0</PackageVersion>
     <Authors>Priyanshu Agrawal</Authors>
     <PackageLicenseUrl>https://github.com/priyanshu92/AsyncMethodNameFixer/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/priyanshu92/AsyncMethodNameFixer</PackageProjectUrl>

--- a/AsyncMethodNameFixer/AsyncMethodNameFixer/AsyncMethodNameFixerAnalyzer.cs
+++ b/AsyncMethodNameFixer/AsyncMethodNameFixer/AsyncMethodNameFixerAnalyzer.cs
@@ -25,7 +25,7 @@ namespace AsyncMethodNameFixer
 
         private static readonly DiagnosticDescriptor NonAsyncRule = new DiagnosticDescriptor(NonAsyncDiagnosticId, NonAsyncTitle, NonAsyncMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: NonAsyncDescription);
 
-        private static readonly IList<string> testMethodAttributes = new List<string> { "TestMethod", "Test", "SetUp", "Theory", "Fact" };
+        private static readonly IList<string> testMethodAttributes = new List<string> { "TestMethod", "Test", "SetUp", "Theory", "Fact", "DataTestMethod" };
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(AsyncRule, NonAsyncRule);
 
@@ -90,6 +90,7 @@ namespace AsyncMethodNameFixer
             return IsAwaitable(methodSymbol)
                 && !methodSymbol.IsOverride
                 && !methodSymbol.Name.Equals("Main")
+                && !methodSymbol.Name.Equals("<Main>$")
                 && !methodSymbol.Name.EndsWith("Async");
         }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pr:
 - master
 
 pool:
-  vmImage: 'VS2017-Win2016'
+  vmImage: 'windows-2022'
 
 variables:
   buildPlatform: 'Any CPU'


### PR DESCRIPTION
- Upgrade to support VS 2022. Fixes #18 
- Remove `DataTestMethod` from warning. Fixes #16 
- Remove `<Main>$` from warning. Fixes #17 