### PR TITLE
look for member in all inherited interface

### DIFF
--- a/AsyncMethodNameFixer/AsyncMethodNameFixer.Test/AsyncMethodNameFixerUnitTests.cs
+++ b/AsyncMethodNameFixer/AsyncMethodNameFixer.Test/AsyncMethodNameFixerUnitTests.cs
@@ -398,6 +398,33 @@ namespace AsyncMethodNameFixer.Test
             ExpectMissingAsync(test, "MyMethod", 8, 42);
         }
 
+        [TestMethod]
+        public void Should_Give_Warning_Only_For_Nested_Interface_Method_Name()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    namespace ConsoleApplication1
+    {
+        interface IFirst
+        {
+            Task MyMethod();
+        }
+
+        interface ISecond : IFirst
+        {
+        }
+
+        class TypeName : ISecond
+        {
+            public Task MyMethod()
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }";
+            ExpectMissingAsync(test, "MyMethod", 7, 18);
+        }
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new AsyncMethodNameFixerCodeFixProvider();

--- a/AsyncMethodNameFixer/AsyncMethodNameFixer/AsyncMethodNameFixerAnalyzer.cs
+++ b/AsyncMethodNameFixer/AsyncMethodNameFixer/AsyncMethodNameFixerAnalyzer.cs
@@ -73,7 +73,7 @@ namespace AsyncMethodNameFixer
 
         private static bool ShouldHaveAsyncInTheEnd(IMethodSymbol methodSymbol)
         {
-            var interfaces = methodSymbol.ContainingType.Interfaces;
+            var interfaces = methodSymbol.ContainingType.AllInterfaces;
 
             foreach (var item in interfaces)
             {


### PR DESCRIPTION
if we have a nested interface, the Analyzer shows a warning for the class that inherited the second interface.
```csharp
interface IFirst
{
    Task MyMethod();
}

interface ISecond : IFirst
{
}

class TypeName : ISecond
{
    public Task MyMethod()
    {
        return Task.CompletedTask;
    }
}
```